### PR TITLE
type: Add is* and is*List type checking functions for all types [#29]

### DIFF
--- a/src/ipc.q
+++ b/src/ipc.q
@@ -43,11 +43,11 @@
 
 / Open a connection to the specified host and port
 /  @param host (Symbol) The hostname to connect to
-/  @param port (Integer) The post to connect to
+/  @param port (Short|Integer|Long) The post to connect to
 /  @return (Integer) The handle to that process if the connection is successful
 /  @see .ipc.connect
 .ipc.connectWithHp:{[host;port]
-    if[(not .type.isSymbol host) | not .type.isInteger port;
+    if[(not .type.isSymbol host) | not .type.isWholeNumber port;
         '"IllegalArgumentException";
     ];
 

--- a/src/type.q
+++ b/src/type.q
@@ -1,41 +1,34 @@
-// Type Checking
-// Copyright (c) 2016 Sport Trades Ltd
+// Type Checking and Normalisation
+// Copyright (c) 2016 - 2020 Sport Trades Ltd
 
 // Documentation: https://github.com/BuaBook/kdb-common/wiki/type.q
 
+/ All infinite values
+/  @see .type.isInfinite
 .type.const.infinites:raze (::;neg)@\:(0Wh;0Wi;0Wj;0We;0Wf;0Wp;0Wm;0Wd;0Wz;0Nn;0Wu;0Wv;0Wt);
 
+/ Mapping of type name based on index in the list (matching .Q.t behaviour)
+.type.const.types:`mixedList`boolean`guid``byte`short`integer`long`real`float`character`symbol`timestamp`month`date`datetime`timespan`minute`second`time;
 
-.type.isSymbol:{
-    :-11h~type x;
+/ Function string to use for all .type.is* functions for higher performance
+.type.const.typeFunc:"{ --TYPE--~type x }";
+
+
+.type.init:{
+    types:.type.const.types where not null .type.const.types;
+    .type.i.setCheckFuncs each types;
  };
+
 
 .type.isString:{
     :10h~type x;
- };
-
-.type.isBoolean:{
-    :-1h~type x;
- };
-
-.type.isTimestamp:{
-    :-12h~type x;
- };
-
-.type.isDate:{
-    :-14h~type x;
- };
-
-.type.isTime:{
-    :-19h~type x;
  };
 
 .type.isNumber:{
     :type[x] in -5 -6 -7 -8 -9h;
  };
 
-/ NOTE: This function checks for a mathematical integer (i.e. whole number)
-.type.isInteger:{
+.type.isWholeNumber:{
     :type[x] in -5 -6 -7h;
  };
 
@@ -52,7 +45,7 @@
  };
 
 .type.isHostPort:{
-    :.type.isInteger[x] | (.type.isSymbol[x] & 2 <= count where ":" = string x);
+    :.type.isLong[x] | (.type.isSymbol[x] & 2 <= count where ":" = string x);
  };
 
 .type.isDict:.type.isDictionary:{
@@ -119,10 +112,6 @@
     :type[x] within 0 19h;
  };
 
-.type.isMixedList:{
-    :0h~type x;
- };
-
 .type.isDistinct:{
     :x~distinct x;
  };
@@ -159,9 +148,29 @@
         '"IllegalArgumentException";
     ];
 
-    if[.type.isInteger x;
+    if[.type.isLong x;
        : `$"::",string x;
     ];
 
     :x;
  };
+
+
+/ Builds type checking functions .type.is*Type* and .type.is*Type*List from a string template function for highest performance
+/  @param typeName (Symbol) The name of the type to build the functions for
+/  @see .type.const.types
+.type.i.setCheckFuncs:{[typeName]
+    listType:`short$.type.const.types?typeName;
+    typeName:@[string typeName; 0; upper];
+
+    atomName:`$"is",typeName;
+    listName:`$"is",typeName,"List";
+
+    set[` sv `.type,atomName;] get ssr[.type.const.typeFunc; "--TYPE--"; .Q.s1 neg listType];
+
+    / If type 0, don't create the list version
+    if[not listType = neg listType;
+        set[` sv `.type,listName;] get ssr[.type.const.typeFunc; "--TYPE--"; .Q.s1 listType];
+    ];
+ };
+

--- a/src/util.q
+++ b/src/util.q
@@ -153,9 +153,7 @@ k).util.showNoLimit:{
 
 /  @param x (List) A list to check if all values are unique
 /  @returns (Boolean) True if the specified list has only unique values
-.util.isDistinct:{
-    :x~distinct x;
- };
+.util.isDistinct:.type.isDistinct;
  
 / String find and replace. If multiple 'find' arguments are supplied the equivalent number of
 / replace arguments must also be specified


### PR DESCRIPTION
 - Created on '.type.init'
 - Bug fix .type.isHostPort returned true for short and integer types which
would then fail if passed into hopen (only long type supported)