### PR TITLE
type: Allow symbol lists in .type.ensureSymbol

### DIFF
--- a/src/type.q
+++ b/src/type.q
@@ -123,7 +123,7 @@
 
 / @returns (Symbol) A symbol version of the input
 .type.ensureSymbol:{
-    if[.type.isSymbol x;
+    if[.type.isSymbol[x] | .type.isSymbolList x;
         :x;
     ];
 


### PR DESCRIPTION
`.type.ensureSymbol` works on lists of strings and would be useful to allow it to work on lists of symbols

```
q).type.ensureSymbol ("abc";"def")
`abc`def
q).type.ensureSymbol `abc`def
'type
  [6]  src/kdb-common/src/type.q:134: .type.ensureSymbol:
    :`$x;
      ^
 }
```
with this change it becomes
```
q).type.ensureSymbol ("abc";"def")
`abc`def
q).type.ensureSymbol `abc`def
`abc`def
```