### PR TITLE
Add new 'env' and 'so' libraries for system interaction

### DIFF
--- a/src/env.q
+++ b/src/env.q
@@ -1,0 +1,89 @@
+// Environemnt Variable Manager
+// Copyright (c) 2020 - 2021 Jaskirat Rajasansir
+
+.require.lib each `type`convert`os;
+
+
+/ Environment variables that should be loaded on library initialisation and optionally parsed by the specified parse function
+/ Specify null symbol to cache the environment variable value on library init as returned by 'getenv'
+/  @see .os.sharedObjectEnvVar
+.env.cfg.vars:(`symbol$())!`symbol$();
+.env.cfg.vars[`QHOME]:                   `.convert.stringToHsym;
+.env.cfg.vars[`QLIC]:                    `.convert.stringToHsym;
+.env.cfg.vars[`PATH]:                    `.env.i.parsePathTypeVar;
+.env.cfg.vars[.os.sharedObjectEnvVar]:   `.env.i.parsePathTypeVar;
+
+
+/ The cached and optionally parsed environment variables
+.env.cache:1#.q;
+
+
+.env.init:{
+    .env.loadAllEnvVars[];
+ };
+
+
+/ Loads all the pre-configured environment variables from the current shell. This can be called at any point to update all environment
+/ variables in the cache
+/  @see .env.cfg.vars
+/  @see .env.i.loadEnvVar
+.env.loadAllEnvVars:{
+    .log.if.info "Loading all configured environment variables [ Total: ",string[count .env.cfg.vars]," ]";
+    .env.i.loadEnvVar ./: flip (key; value) @\: .env.cfg.vars;
+ };
+
+/ Queries the specified environment varaible either from the cache or directly via 'getenv' if not pre-configured
+/  @param envVar (Symbol) The environment variable to query
+/  @returns () The raw environment variable or the parsed result
+/  @throws EnvironmentVariableNotDefinedException If the environment variable is not set in the cache and an empty value from 'getenv'
+/  @see .env.cache
+/  @see getenv
+.env.get:{[envVar]
+    if[not envVar in key .env.cache;
+        envVal:getenv envVar;
+
+        if[0 = count envVal;
+            '"EnvironmentVariableNotDefinedException";
+        ];
+
+        :envVal;
+    ];
+
+    :.env.cache envVar;
+ };
+
+
+/ Loads and optionally parses the specified environment variable with the specified parse function reference
+/  @param envVar (Symbol) The environment variable to parse
+/  @param parseFunc (Symbol) Function reference for the parse function. If null, no parse is performed
+/  @see .env.cache
+.env.i.loadEnvVar:{[envVar; parseFunc]
+    .log.if.debug "Loading environment variable [ Variable: ",string[envVar]," ] [ Parse Function: ",string[`none ^ parseFunc]," ]";
+
+    envVal:getenv envVar;
+
+    if[not null parseFunc;
+        envVal:get[parseFunc] envVal;
+    ];
+
+    .env.cache[envVar]:envVal;
+ };
+
+
+/ Parses a '$PATH'-type environment variable into a list of folder paths for use within kdb+
+/ NOTE: Only valid folders will be returned from this function
+/  @param rawPath (String) The environment variable output
+/  @returns (FolderPathList) The list of valid folders from the '$PATH'-type environment variable or empty symbol list if environment variable not set
+/  @see .type.isFolder
+.env.i.parsePathTypeVar:{[rawPath]
+    paths:.os.envPathSeparator vs rawPath;
+
+    if[0 = count paths;
+        :`symbol$();
+    ];
+
+    paths:`$":",/:paths;
+    paths@:where .type.isFolder each paths;
+
+    :paths;
+ };

--- a/src/env.q
+++ b/src/env.q
@@ -69,7 +69,6 @@
     .env.cache[envVar]:envVal;
  };
 
-
 / Parses a '$PATH'-type environment variable into a list of folder paths for use within kdb+
 / NOTE: Only valid folders will be returned from this function
 /  @param rawPath (String) The environment variable output

--- a/src/os.q
+++ b/src/os.q
@@ -5,13 +5,35 @@
 
 .require.lib each `util`type;
 
+
+/ The separator characters for PATH-type environment variables in all configured OSs
+.os.cfg.envPathSeparator:(`symbol$())!`char$();
+.os.cfg.envPathSeparator[`l`v`m]:":";
+.os.cfg.envPathSeparator[`w]:";";
+
+/ The PATH-type environment variable for shared object / DLL loading for all configured OSs
+.os.cfg.sharedObjectEnvVar:(`symbol$())!`symbol$();
+.os.cfg.sharedObjectEnvVar[`l`v]:`LD_LIBRARY_PATH;
+.os.cfg.sharedObjectEnvVar[`m]:`DYLD_LIBRARY_PATH;
+.os.cfg.sharedObjectEnvVar[`w]:`PATH;
+
+
 / The current operating system, independent of architecture
 /  @see .os.i.getOsType
 .os.type:`;
 
+/ The separator character for PATH-type environment variables in the current OS
+.os.envPathSeparator:" ";
+
+/ The environment variable containing the PATH-type environment variable for shared object / DLL loading
+.os.sharedObjectEnvVar:`;
+
 
 .os.init:{
     .os.type:.os.i.getOsType[];
+
+    .os.envPathSeparator:.os.cfg.envPathSeparator .os.type;
+    .os.sharedObjectEnvVar:.os.cfg.sharedObjectEnvVar .os.type;
  };
 
 / Runs the specified command with the specified parameters. NOTE: That not

--- a/src/so.q
+++ b/src/so.q
@@ -1,0 +1,90 @@
+// Shared Object Function Manager
+// Copyright (c) 2020 - 2021 Jaskirat Rajasansir
+
+.require.lib each `type`file`time`ns`os`env;
+
+
+/ The target namespace that all shared library functions will be loaded into
+.so.cfg.targetNs:`.so.libs;
+
+
+/ Store of all loaded shared library functions
+.so.loaded:`kdbRef xkey flip `kdbRef`soName`soPath`soFunctionName`loadTime!"SSSSP"$\:();
+
+
+.so.init:{
+    .log.if.info "Shared object namespace [ Namespace: ",string[.so.cfg.targetNs]," ]";
+    set[.so.cfg.targetNs; 1#.q];
+ };
+
+
+/ Attempts to find a shared object with the specified name within the paths specified by the source environment variable
+/ NOTE: If multiple files match the specified name, only the first will be returned
+/  @param soName (String|Symbol) The shared object name to search for, including suffix
+/  @returns (FilePath) Path to the matching shared object file, or empty symbol if no matching file found
+/  @see .os.sharedObjectEnvVar
+/  @see .env.get
+.so.findSharedObject:{[soName]
+    soPaths:raze .file.findFilePaths["*",.type.ensureString soName;] each .env.get .os.sharedObjectEnvVar;
+
+    if[0 = count soPaths;
+        .log.if.warn "No matching paths found for shared object [ Shared Object: ",.type.ensureString[soName]," ] [ Source Env Var: ",string[.os.sharedObjectEnvVar]," ]";
+        :`;
+    ];
+
+    if[1 < count soPaths;
+        .log.if.warn "Multiple matching files for shared objects. Returning first [ Shared Object: ",.type.ensureString[soName]," ] [ Matching: ",string[count soPaths]," ]";
+    ];
+
+    :first soPaths;
+ };
+
+/ Loads the specified function from the specified shared object into the process
+/ NOTE: If the function is already loaded into the process, it will not be reloaded
+/  @param soName (Symbol|FilePath) The name of the shared object to find, or the specific shared object to load the function from
+/  @param soFunctionName (Symbol) The function to reference in the shared object
+/  @param soFunctionArgs (Long) The number of arguments the function in the shared object requires to execute
+/  @returns (Symbol) Namespace reference to the shared object code loaded into the current process
+/  @throws SharedObjectNotFoundException If the specified shared object is a name and a matching file could not be found
+/  @see .so.cfg.targetNs
+/  @see .so.findSharedObject
+.so.loadFunction:{[soName; soFunctionName; soFunctionArgs]
+    if[not all .type.isSymbol each (soName; soFunctionName);
+        '"InvalidArgumentException";
+    ];
+
+    if[not .type.isLong soFunctionArgs;
+        '"InvalidArgumentException";
+    ];
+
+    soPath:soName;
+
+    if[not .type.isFilePath soPath;
+        soPath:.so.findSharedObject soName;
+    ];
+
+    if[null soPath;
+        '"SharedObjectNotFoundException";
+    ];
+
+    / Remove file suffix from shared object path for 2:
+    soLoadPath:` sv @[` vs soPath; 1; first ` vs];
+
+    kdbFunctionName:` sv .so.cfg.targetNs,last[` vs soLoadPath],soFunctionName;
+
+    if[.ns.isSet kdbFunctionName;
+        .log.if.info "Shared object function already loaded [ Shared Object: ",string[soName]," ] [ Function: ",string[soFunctionName]," ]";
+        :kdbFunctionName;
+    ];
+
+    .log.if.info "Loading function from shared object [ Shared Object: ",string[soName]," (",string[soPath],") ] [ Function: ",string[soFunctionName]," -> ",string[kdbFunctionName]," ] [ Args: ",string[soFunctionArgs]," ]";
+
+    set[kdbFunctionName;] soLoadPath 2: (soFunctionName; soFunctionArgs);
+
+    .so.loaded[kdbFunctionName]:(soName; soPath; soFunctionName; .time.now[]);
+
+    .log.if.info "Shared object function loaded OK [ Shared Object: ",string[soName]," ] [ Function: ",string[kdbFunctionName]," ]";
+
+    :kdbFunctionName;
+ };
+


### PR DESCRIPTION
Extracting functionality from [kdb-systemd](https://github.com/jasraj/kdb-systemd) and [kdb-base64](https://github.com/jasraj/kdb-base64) to find shared objects from the correct location on disk.

Currently only looks in `LD_LIBRARY_PATH` or equivalent on other OSs