### PR TITLE
log: Add support for pattern-based logging and call line tracing

### DIFF
--- a/src/log.loggers.q
+++ b/src/log.loggers.q
@@ -1,0 +1,27 @@
+// Logging
+// Copyright (c) 2015 - 2017 Sport Trades Ltd, 2020 - 2021 Jaskirat Rajasansir
+
+/ Basic logger
+.log.loggers.basic:{[formatter; fd; lvl; message]
+    fd " " sv formatter[5$string lvl; message];
+ };
+
+/ Logger with color highlighting of the level based on the configuration in .log.levels
+.log.loggers.color:{[formatter; fd; lvl; message]
+    lvl:(.log.levels[lvl]`color),(5$string lvl),.log.resetColor;
+    fd " " sv formatter[lvl; message];
+ };
+
+/ Non-color logger with the additional syslog priority prefix at the start of the log line. This is useful
+/ when capturing log output into systemd (via 'systemd-cat').
+.log.loggers.syslog:{[formatter; fd; lvl; message]
+    syslogLvl:"<",string[.log.levels[lvl]`syslog],">";
+    fd " " sv enlist[syslogLvl],formatter[5$string lvl; message];
+ };
+
+/ JSON logger
+/ NOTE: This logger does not do the slf4j-style parameterised replacement of the message but prints as the supplied list
+.log.loggers.json:{[formatter; fd; lvl; message]
+    logElems:`date`time`level`processId`user`handle`message!(.time.today[]; .time.nowAsTime[]; lvl; .log.process; `system^.z.u; .z.w; message);
+    fd .j.j logElems;
+ };


### PR DESCRIPTION
 - All string loggers now pad the log level to improve readability
 - Loggers moved into log.loggers.q
 - Re-organisation of logging constants and configuration

## Performance Testing

### Equivalent Logging

Comparing the new pattern-based logging (increased flexibility) vs the old logger (fixed): 

```q
/ model name      : Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz

/ Setup
q) dict:`a`b`c!1 2 3;

/ For new pattern-based logging (matching original logger)
q) .log.cfg.format:"%d %t %l %p %u %h %m"
q) .log.setLogger[]

q) .log.info "A dictionary: ",.Q.s1 dict;                                   / Original
q) .log.info ("A dictionary: {}"; dict);                                    / Parameterised
```

Results:

| Formatter | Log Format    | Iterations | `ts`         |
| --------- | ------------- | ---------- | ------------ |
| Fixed     | Original      | 1000       | `20 4195376` |
| Pattern   | Original      | 1000       | `22 4195376` |
|           |               |            |
| Fixed     | Parameterised | 1000      | `21 4195264` |
| Pattern   | Parameterised | 1000      | `24 4195264` |

The pattern-based logging has ~10% degradation in performance when logging with the same elements as the original logging.

### Call Trace Logging

```q
/ model name      : Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz

/ Setup
q) .test.log:{ .log.info "Logging test" };

/ Original logger pattern
q) .log.cfg.format:"%d %t %l %p %u %h %m"
q) .log.setLogger[]

/ Logger pattern with call trace logging
q) .log.cfg.format:"%d %t %l %p %u %h %T %m"
q) .log.setLogger[]

q) \ts do[1000; .test.log[]; ]
```

Results:

| Call Tracing | Iterations | `ts`         |
| ------------ | ---------- | ------------ |
| NO           | 1000       | `12 4195088` |
| YES          | 1000       | `28 4195088` |

Including call-trace logging in the formatting has ~130% degradation in performance