### PR TITLE
os: Fix .os.getTerminalSize for Mac

### DIFF
--- a/src/os.q
+++ b/src/os.q
@@ -75,7 +75,7 @@
     rawTermSize:trim .os.run[`terminalSize; ""];
     termSize:"";
 
-    $[`l = .os.type;
+    $[.os.type in `l`m;
         termSize:" " vs first rawTermSize;
     `w = .os.type;
         termSize:trim last each ":" vs/: rawTermSize raze where each rawTermSize like/: ("Lines:*"; "Columns:*")


### PR DESCRIPTION
Related to [#96] - fixes the error that occurs when `terminal` is loaded in a Mac-based kdb process